### PR TITLE
PDF

### DIFF
--- a/resources/views/pdfs/controle.blade.php
+++ b/resources/views/pdfs/controle.blade.php
@@ -12,6 +12,7 @@
   </tr>
 </table>
 
+<br><br><br><br><br><br>
 <table class="table table-striped">
   <thead>
     <tr align="center">


### PR DESCRIPTION
Para corrigir o erro de exportação do PDF, mudei a linha que estava dando erro, no arquivo Style.php para isso:
if (round((int)$val) != $val && $val !== "auto") {
            return;
        }

Pelo o que eu vi, esse é um erro de versão da biblioteca dompdf
https://github.com/barryvdh/laravel-dompdf/issues/757

fix #167 