### PR TITLE
Colocando a etiqueta A4256 como primeira opção, pois ela era a "default"

### DIFF
--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -181,8 +181,8 @@ class Item extends Model
 
     public static function etiquetaOptions(){
         return[
-            '6182',
             'A4256',
+            '6182',
             '3080',
             '3081',
             '3082',
@@ -282,6 +282,4 @@ class Item extends Model
             'BOOP100x40',
         ];
     }
-
 }
-


### PR DESCRIPTION
Solicitado pelo administrador do sistema, a opção de etiqueta foi colocada como primeira opção para facilitar o uso