### PR TITLE
Alterando o font-size para resolver o problema de espaço das etiquetas

### DIFF
--- a/resources/views/pdfs/etiquetas.blade.php
+++ b/resources/views/pdfs/etiquetas.blade.php
@@ -1,7 +1,7 @@
 <table style='width:100%; padding:2px; margin:{{$margem}}; border: 0px solid #000'>
     <tr>
         <td style='width:60%;'>
-            <span style='font-size: 9px'>
+            <span style='font-size: 8.5px'>
             @if(!empty($item->verba))<b>Verba: </b>{!! App\Utils\Util::limita_caracteres($item->verba , $limiteCaracteres) !!}<br>@endif
             <b>Aquisição: </b>{!! App\Utils\Util::limita_caracteres($item->tipo_aquisicao , $limiteCaracteres) !!}<br>
             @if(!empty($item->processo))<b>Processo: </b> {{ $item->processo }}<br>@endif


### PR DESCRIPTION
Na hora de gerar o pdf das etiquetas, o sistema pulava as últimas linhas ao selecionar o tipo A4256, ficando somente 30 por página, ao invés de 33. Então, mudei o font-size para um tamanho menor para que apareça 33 itens por página, não deixando nenhum espaço em branco.

Para testar, tente inserir o algum número de valor baixo (como 1) no "tombo inicio" e o número completo de algum tombo no campo "tombo fim" (420123 por exemplo)